### PR TITLE
Add support for MSVC and Windows-on-ARM to GetTimeCounter()

### DIFF
--- a/libsrc/core/utils.hpp
+++ b/libsrc/core/utils.hpp
@@ -74,6 +74,8 @@ namespace ngcore
     return tics;
 #elif defined(__EMSCRIPTEN__)
     return std::chrono::high_resolution_clock::now().time_since_epoch().count();
+#elif defined(_MSC_VER) && defined(_M_ARM64)
+    return std::chrono::high_resolution_clock::now().time_since_epoch().count();
 #else
 #warning "Unsupported CPU architecture"
     return 0;


### PR DESCRIPTION
Windows-on-ARM with MSVC can use the same method as the` __EMSCRIPTEN__` branch. I duplicated the branch to avoid overly-complicated conditionals, but an alternative would be to combine the two.